### PR TITLE
Closes DanielHreben/sequelize-transparent-cache#2

### DIFF
--- a/lib/cache/index.js
+++ b/lib/cache/index.js
@@ -9,17 +9,31 @@ function getInstanceModel (instance) {
     : instance.Model
 }
 
+function getModelPrimaryKeys (instance) {
+  return getInstanceModel(instance).describe().then(
+    (schema) => {
+      return Object.keys(schema).filter(function (field) {
+        return schema[field].primaryKey
+      })
+    }
+  ).then(
+    (keys) => keys.map((k) => instance[k])
+  )
+}
+
 function save (client, instance) {
   if (!instance) {
     return instance
   }
-
-  const key = [
-    getInstanceModel(instance).name,
-    instance.id
-  ]
-
-  return client.set(key, instanceToData(instance)).then(() => instance)
+  return getModelPrimaryKeys(instance).then(
+    (keys) => {
+      const key = [
+        getInstanceModel(instance).name,
+        ...keys
+      ]
+      return client.set(key, instanceToData(instance)).then(() => instance)
+    }
+  )
 }
 
 function get (client, model, id) {
@@ -38,12 +52,15 @@ function destroy (client, instance) {
     return instance
   }
 
-  const key = [
-    getInstanceModel(instance).name,
-    instance.id
-  ]
-
-  return client.del(key)
+  return getModelPrimaryKeys(instance).then(
+    (keys) => {
+      const key = [
+        getInstanceModel(instance).name,
+        keys
+      ]
+      return client.del(key)
+    }
+  )
 }
 
 module.exports = {

--- a/test/classMethods.js
+++ b/test/classMethods.js
@@ -2,6 +2,7 @@ const t = require('tap')
 const sequelize = require('./helpers/sequelize')
 
 const User = sequelize.models.User
+const Person = sequelize.models.Person
 const cacheStore = User.cache().client().store
 
 t.test('Instance methods', async t => {
@@ -14,17 +15,46 @@ t.test('Instance methods', async t => {
     name: 'Daniel'
   })
 
+  const mike = await Person.cache().create({
+    name: 'Mike'
+  })
+
+  const alex = await Person.cache().create({
+    name: 'Alex'
+  })
+
   t.test('Create', async t => {
     t.deepEqual(
       cacheStore.User[1],
       user.get(),
-      'User cached afrer create'
+      'User with primary key cached after create'
     )
-
+    console.log(cacheStore)
+    t.deepEqual(
+      cacheStore.Person[1],
+      mike.get(),
+      'Entity without primary key cached after create using autoincrement id'
+    )
+    t.deepEqual(
+      cacheStore.Person[2],
+      alex.get(),
+      'Entity without primary key cached after create using autoincrement id'
+    )
     t.deepEqual(
       (await User.cache().findById(1)).get(),
       user.get(),
-      'Cached user correctly loaded'
+      'Cached user with primary key correctly loaded'
+    )
+
+    t.deepEqual(
+      (await Person.cache().findById(1)).get(),
+      mike.get(),
+      'Cached entity without primary key correctly loaded using auto increment id'
+    )
+    t.deepEqual(
+      (await Person.cache().findById(2)).get(),
+      alex.get(),
+      'Cached entity without primary key correctly loaded using auto increment id'
     )
   })
 

--- a/test/helpers/sequelize.js
+++ b/test/helpers/sequelize.js
@@ -25,12 +25,24 @@ sequelize.define('User', {
   name: {
     allowNull: false,
     type: Sequelize.STRING
+  },
+  id: {
+    type: Sequelize.INTEGER,
+    primaryKey: true
+  }
+})
+
+sequelize.define('Person', {
+  name: {
+    allowNull: false,
+    type: Sequelize.STRING
   }
 })
 
 if (Sequelize.version.startsWith('4')) { // Using class extention
   const { withCache } = sequelizeCache(variableAdaptor)
   withCache(sequelize.models.User)
+  withCache(sequelize.models.Person)
 }
 
 module.exports = sequelize


### PR DESCRIPTION
Now lib will look automatically for primary keys and use them when generating cache keys