### PR TITLE
use model.primaryKeyAttributes instead of model.describe()

### DIFF
--- a/lib/cache/index.js
+++ b/lib/cache/index.js
@@ -9,7 +9,7 @@ function getInstanceModel (instance) {
     : instance.Model
 }
 
-function getModelPrimaryKeys (instance) {
+function getModelCacheKeys (instance) {
   return getInstanceModel(instance).primaryKeyAttributes.map((k) => instance[k])
 }
 
@@ -19,7 +19,7 @@ function save (client, instance) {
   }
   const key = [
     getInstanceModel(instance).name,
-    ...getModelPrimaryKeys(instance)
+    ...getModelCacheKeys(instance)
   ]
   return client.set(key, instanceToData(instance)).then(() => instance)
 }
@@ -42,7 +42,7 @@ function destroy (client, instance) {
 
   const key = [
     getInstanceModel(instance).name,
-    ...getModelPrimaryKeys(instance)
+    ...getModelCacheKeys(instance)
   ]
   return client.del(key)
 }

--- a/lib/cache/index.js
+++ b/lib/cache/index.js
@@ -10,30 +10,18 @@ function getInstanceModel (instance) {
 }
 
 function getModelPrimaryKeys (instance) {
-  return getInstanceModel(instance).describe().then(
-    (schema) => {
-      return Object.keys(schema).filter(function (field) {
-        return schema[field].primaryKey
-      })
-    }
-  ).then(
-    (keys) => keys.map((k) => instance[k])
-  )
+  return getInstanceModel(instance).primaryKeyAttributes.map((k) => instance[k])
 }
 
 function save (client, instance) {
   if (!instance) {
     return instance
   }
-  return getModelPrimaryKeys(instance).then(
-    (keys) => {
-      const key = [
-        getInstanceModel(instance).name,
-        ...keys
-      ]
-      return client.set(key, instanceToData(instance)).then(() => instance)
-    }
-  )
+  const key = [
+    getInstanceModel(instance).name,
+    ...getModelPrimaryKeys(instance)
+  ]
+  return client.set(key, instanceToData(instance)).then(() => instance)
 }
 
 function get (client, model, id) {
@@ -52,15 +40,11 @@ function destroy (client, instance) {
     return instance
   }
 
-  return getModelPrimaryKeys(instance).then(
-    (keys) => {
-      const key = [
-        getInstanceModel(instance).name,
-        keys
-      ]
-      return client.del(key)
-    }
-  )
+  const key = [
+    getInstanceModel(instance).name,
+    ...getModelPrimaryKeys(instance)
+  ]
+  return client.del(key)
 }
 
 module.exports = {

--- a/lib/cache/index.js
+++ b/lib/cache/index.js
@@ -9,17 +9,31 @@ function getInstanceModel (instance) {
     : instance.Model
 }
 
+function getModelPrimaryKeys (instance) {
+  return getInstanceModel(instance).describe().then(
+    (schema) => {
+      return Object.keys(schema).filter(function (field) {
+        return schema[field].primaryKey
+      })
+    }
+  ).then(
+    (keys) => keys.map((k) => instance[k])
+  )
+}
+
 function save (client, instance) {
   if (!instance) {
     return instance
   }
-
-  const key = [
-    getInstanceModel(instance).name,
-    instance.id
-  ]
-
-  return client.set(key, instanceToData(instance)).then(() => instance)
+  return getModelPrimaryKeys(instance).then(
+    (keys) => {
+      const key = [
+        getInstanceModel(instance).name,
+        ...keys
+      ]
+      return client.set(key, instanceToData(instance)).then(() => instance)
+    }
+  )
 }
 
 function get (client, model, id) {
@@ -38,12 +52,15 @@ function destroy (client, instance) {
     return instance
   }
 
-  const key = [
-    getInstanceModel(instance).name,
-    instance.id
-  ]
-
-  return client.del(key)
+  return getModelPrimaryKeys(instance).then(
+    (keys) => {
+      const key = [
+        getInstanceModel(instance).name,
+        keys
+      ]
+      return client.del(key)
+    }
+  )
 }
 
 module.exports = {

--- a/test/classMethods.js
+++ b/test/classMethods.js
@@ -2,7 +2,8 @@ const t = require('tap')
 const sequelize = require('./helpers/sequelize')
 
 const User = sequelize.models.User
-const Person = sequelize.models.Person
+const Article = sequelize.models.Article
+const Comment = sequelize.models.Comment
 const cacheStore = User.cache().client().store
 
 t.test('Instance methods', async t => {
@@ -15,29 +16,31 @@ t.test('Instance methods', async t => {
     name: 'Daniel'
   })
 
-  const mike = await Person.cache().create({
-    name: 'Mike'
+  const article = await Article.cache().create({
+    uuid: '2086c06e-9dd9-4ee3-84b9-9e415dfd9c4c',
+    title: 'New article'
   })
 
-  const alex = await Person.cache().create({
-    name: 'Alex'
+  const comment = await Comment.cache().create({
+    user_id: user.id,
+    article_uuid: article.uuid,
+    body: 'New comment'
   })
-
   t.test('Create', async t => {
     t.deepEqual(
       cacheStore.User[1],
       user.get(),
-      'User with primary key cached after create'
+      'User with default primary key cached after create'
     )
     t.deepEqual(
-      cacheStore.Person[1],
-      mike.get(),
-      'Entity without primary key cached after create using autoincrement id'
+      cacheStore.Article[article.uuid],
+      article.get(),
+      'Entity with custom primary key cached after create'
     )
     t.deepEqual(
-      cacheStore.Person[2],
-      alex.get(),
-      'Entity without primary key cached after create using autoincrement id'
+      cacheStore.Comment[`${comment.user_id},${comment.article_uuid}`],
+      comment.get(),
+      'Entity with composite primary keys cached after create'
     )
     t.deepEqual(
       (await User.cache().findById(1)).get(),
@@ -46,14 +49,9 @@ t.test('Instance methods', async t => {
     )
 
     t.deepEqual(
-      (await Person.cache().findById(1)).get(),
-      mike.get(),
-      'Cached entity without primary key correctly loaded using auto increment id'
-    )
-    t.deepEqual(
-      (await Person.cache().findById(2)).get(),
-      alex.get(),
-      'Cached entity without primary key correctly loaded using auto increment id'
+      (await Article.cache().findById(article.uuid)).get(),
+      article.get(),
+      'Cached entity correctly loaded using custom primary key'
     )
   })
 

--- a/test/classMethods.js
+++ b/test/classMethods.js
@@ -2,6 +2,7 @@ const t = require('tap')
 const sequelize = require('./helpers/sequelize')
 
 const User = sequelize.models.User
+const Person = sequelize.models.Person
 const cacheStore = User.cache().client().store
 
 t.test('Instance methods', async t => {
@@ -14,17 +15,46 @@ t.test('Instance methods', async t => {
     name: 'Daniel'
   })
 
+  const mike = await Person.cache().create({
+    name: 'Mike'
+  })
+
+  const alex = await Person.cache().create({
+    name: 'Alex'
+  })
+
   t.test('Create', async t => {
     t.deepEqual(
       cacheStore.User[1],
       user.get(),
-      'User cached afrer create'
+      'User with primary key cached after create'
     )
-
+    console.log(cacheStore)
+    t.deepEqual(
+      cacheStore.Person[1],
+      mike.get(),
+      'Entity without primary key cached after create using autoincrement id'
+    )
+    t.deepEqual(
+      cacheStore.Person[2],
+      alex.get(),
+      'Entity without primary key cached after create using autoincrement id'
+    )
     t.deepEqual(
       (await User.cache().findById(1)).get(),
       user.get(),
-      'Cached user correctly loaded'
+      'Cached user with primary key correctly loaded'
+    )
+
+    t.deepEqual(
+      (await Person.cache().findById(1)).get(),
+      mike.get(),
+      'Cached entity without primary key correctly loaded using auto increment id'
+    )
+    t.deepEqual(
+      (await Person.cache().findById(2)).get(),
+      alex.get(),
+      'Cached entity without primary key correctly loaded using auto increment id'
     )
   })
 

--- a/test/classMethods.js
+++ b/test/classMethods.js
@@ -29,7 +29,6 @@ t.test('Instance methods', async t => {
       user.get(),
       'User with primary key cached after create'
     )
-    console.log(cacheStore)
     t.deepEqual(
       cacheStore.Person[1],
       mike.get(),

--- a/test/helpers/sequelize.js
+++ b/test/helpers/sequelize.js
@@ -25,15 +25,33 @@ sequelize.define('User', {
   name: {
     allowNull: false,
     type: Sequelize.STRING
-  },
-  id: {
-    type: Sequelize.INTEGER,
-    primaryKey: true
   }
 })
 
-sequelize.define('Person', {
-  name: {
+sequelize.define('Article', {
+  uuid: {
+    allowNull: false,
+    type: Sequelize.STRING,
+    primaryKey: true
+  },
+  title: {
+    allowNull: false,
+    type: Sequelize.STRING
+  }
+})
+
+sequelize.define('Comment', {
+  user_id: {
+    allowNull: false,
+    type: Sequelize.INTEGER,
+    primaryKey: true
+  },
+  article_uuid: {
+    allowNull: false,
+    type: Sequelize.STRING,
+    primaryKey: true
+  },
+  body: {
     allowNull: false,
     type: Sequelize.STRING
   }
@@ -42,7 +60,8 @@ sequelize.define('Person', {
 if (Sequelize.version.startsWith('4')) { // Using class extention
   const { withCache } = sequelizeCache(variableAdaptor)
   withCache(sequelize.models.User)
-  withCache(sequelize.models.Person)
+  withCache(sequelize.models.Article)
+  withCache(sequelize.models.Comment)
 }
 
 module.exports = sequelize

--- a/test/helpers/sequelize.js
+++ b/test/helpers/sequelize.js
@@ -25,12 +25,24 @@ sequelize.define('User', {
   name: {
     allowNull: false,
     type: Sequelize.STRING
+  },
+  id: {
+    type: Sequelize.INTEGER,
+    primaryKey: true
+  }
+})
+
+sequelize.define('Person', {
+  name: {
+    allowNull: false,
+    type: Sequelize.STRING
   }
 })
 
 if (Sequelize.version.startsWith('4')) { // Using class extention
   const { withCache } = sequelizeCache(variableAdaptor)
   withCache(sequelize.models.User)
+  withCache(sequelize.models.Person)
 }
 
 module.exports = sequelize


### PR DESCRIPTION
Closes DanielHreben/sequelize-transparent-cache#2

A better way to extract model primary keys to use in cache key generation