### PR TITLE
[adaptor-ioredis] fix getting data has buffer value

### DIFF
--- a/packages/sequelize-transparent-cache-ioredis/IORedisAdaptor.js
+++ b/packages/sequelize-transparent-cache-ioredis/IORedisAdaptor.js
@@ -33,7 +33,11 @@ class IORedisAdaptor {
         return data
       }
 
-      return JSON.parse(data)
+      return JSON.parse(data, (key, value) => {
+        return value && value.type === 'Buffer' ?
+          Buffer.from(value.data) :
+          value;
+      })
     })
   }
 

--- a/packages/sequelize-transparent-cache-ioredis/IORedisAdaptor.js
+++ b/packages/sequelize-transparent-cache-ioredis/IORedisAdaptor.js
@@ -34,9 +34,9 @@ class IORedisAdaptor {
       }
 
       return JSON.parse(data, (key, value) => {
-        return value && value.type === 'Buffer' ?
-          Buffer.from(value.data) :
-          value;
+        return value && value.type === 'Buffer'
+          ? Buffer.from(value.data)
+          : value
       })
     })
   }


### PR DESCRIPTION
If a model has a `Sequelize.BLOB` column, this bug will case data overwrite with `'[object Object]'`.

See https://nodejs.org/api/buffer.html#buffer_buf_tojson