### PR TITLE
Look for model associations and load them on instance build

### DIFF
--- a/packages/sequelize-transparent-cache/lib/cache/util.js
+++ b/packages/sequelize-transparent-cache/lib/cache/util.js
@@ -1,13 +1,25 @@
 function instanceToData (instance) {
-  return instance.get({plain: true})
+  return instance.get({ plain: true })
 }
 
 function dataToInstance (model, data) {
   if (!data) {
     return data
   }
-
-  const instance = model.build(data, { isNewRecord: false })
+  let include = []
+  if (model.associations) {
+    Object.keys(model.associations).forEach((key) => {
+      const association = {}
+      //  model.associations[key] does not work on include, we grab it from sequelize.model()
+      if (model.associations[key].hasOwnProperty('options')) {
+        let modelName = model.associations[key].options.name.singular
+        association.model = model.sequelize.model(modelName)
+        association.as = key
+      }
+      include.push(association)
+    })
+  }
+  const instance = model.build(data, { isNewRecord: false, include })
 
   if (data.updatedAt) {
     instance.setDataValue('updatedAt', data.updatedAt)


### PR DESCRIPTION
Enhancement of what was pointed out on issue 17:

https://github.com/DanielHreben/sequelize-transparent-cache/issues/17

Added the needed include for associations being also loaded when the instance is built. 

