### PR TITLE
Add clear method to manually clear instance cache

### DIFF
--- a/packages/sequelize-transparent-cache/lib/methods/instance.js
+++ b/packages/sequelize-transparent-cache/lib/methods/instance.js
@@ -2,33 +2,27 @@ const cache = require('../cache')
 
 function instanceMethods (client, instance) {
   return {
-    client () {
-      return client
-    },
+    client () { return client },
     save () {
       return instance.save.apply(instance, arguments)
       .then(instance => cache.save(client, instance))
     },
-
     update () {
       return instance.update
       .apply(instance, arguments)
       .then(instance => cache.save(client, instance))
     },
-
     reload () {
       return instance.reload
       .apply(instance, arguments)
       .then(instance => cache.save(client, instance))
     },
-
     destroy () {
       return instance.destroy.apply(instance, arguments)
       .then(() => cache.destroy(client, instance))
     },
-    
     clear () {
-      cache.destroy(client, instance)
+      return cache.destroy(client, instance)
     }
   }
 }

--- a/packages/sequelize-transparent-cache/lib/methods/instance.js
+++ b/packages/sequelize-transparent-cache/lib/methods/instance.js
@@ -25,6 +25,10 @@ function instanceMethods (client, instance) {
     destroy () {
       return instance.destroy.apply(instance, arguments)
       .then(() => cache.destroy(client, instance))
+    },
+    
+    clear () {
+      cache.destroy(client, instance)
     }
   }
 }

--- a/packages/sequelize-transparent-cache/test/instanceMethods.js
+++ b/packages/sequelize-transparent-cache/test/instanceMethods.js
@@ -43,6 +43,19 @@ t.test('Instance methods', async t => {
       'User cached afrer upsert'
     )
   })
+  t.test('Clear', async t => {
+    t.deepEqual(
+      (await User.cache().findById(1)).get(),
+      user.get(),
+      'Cached user correctly loaded'
+    )
+    await user.cache().clear()
+
+    t.notOk(
+      cacheStore.User[1],
+      'User was deleted from cache'
+    )
+  })
 
   t.test('Destroy', async t => {
     await user.cache().destroy()


### PR DESCRIPTION
I'm opening this PR, because I found myself doing writing this type of methods more than once for my models:

```javascript
Model.prototype.clearCache = function() {
        const redisClient = this.cache().client();
        redisClient.del(['model', this.id]);
};
```

Sometimes when doing fancy stuff you want to manually clear the cache, without the need of doing a Sequelize operation in the middle. 

This is why i'm proposing this feature were we can clear cache on any instance by doing:

`instance.cache().clear()`

Let me know if you have any questions or concerns.