### PR TITLE
Feature/Added manualCache() methods including clear and findAll

### DIFF
--- a/packages/sequelize-transparent-cache/lib/cache/index.js
+++ b/packages/sequelize-transparent-cache/lib/cache/index.js
@@ -13,14 +13,20 @@ function getInstanceCacheKey (instance) {
   return getInstanceModel(instance).primaryKeyAttributes.map(pk => instance[pk])
 }
 
-function save (client, instance) {
+function save (client, instance, customId) {
   if (!instance) {
     return instance
   }
-  const key = [
-    getInstanceModel(instance).name,
-    ...getInstanceCacheKey(instance)
-  ]
+  let key = [getInstanceModel(instance).name]
+  if (customId !== undefined) {
+    key.push(
+      customId
+    )
+  } else {
+    key.push(
+      ...getInstanceCacheKey(instance)
+    )
+  }
   return client.set(key, instanceToData(instance)).then(() => instance)
 }
 
@@ -47,8 +53,17 @@ function destroy (client, instance) {
   return client.del(key)
 }
 
+function clearKey (client, model, customKey) {
+  const key = [
+    model.name,
+    customKey
+  ]
+  return client.del(key)
+}
+
 module.exports = {
   save,
   get,
-  destroy
+  destroy,
+  clearKey
 }

--- a/packages/sequelize-transparent-cache/lib/index.js
+++ b/packages/sequelize-transparent-cache/lib/index.js
@@ -1,5 +1,8 @@
-const classMethods = require('./methods/class')
+const methods = require('./methods/class')
 const instanceMethods = require('./methods/instance')
+
+const manualCacheMethods = methods.manualCacheMethods
+const classMethods = methods.classMethods
 
 module.exports = function (client) {
   /* istanbul ignore next: covered, but depends on installed sequelize version */
@@ -7,6 +10,10 @@ module.exports = function (client) {
     withCache (modelClass) {
       modelClass.cache = function () {
         return classMethods(client, this)
+      }
+
+      modelClass.manualCache = function (customId) {
+        return manualCacheMethods(client, this, customId)
       }
 
       modelClass.prototype.cache = function () {
@@ -18,6 +25,11 @@ module.exports = function (client) {
     classMethods: {
       cache () {
         return classMethods(client, this)
+      }
+    },
+    manualCacheMethods: {
+      manualCache (customId) {
+        return manualCacheMethods(client, this, customId)
       }
     },
     instanceMethods: {

--- a/packages/sequelize-transparent-cache/lib/index.js
+++ b/packages/sequelize-transparent-cache/lib/index.js
@@ -23,19 +23,13 @@ module.exports = function (client) {
       return modelClass
     },
     classMethods: {
-      cache () {
-        return classMethods(client, this)
-      }
+      cache () { return classMethods(client, this) }
     },
     manualCacheMethods: {
-      manualCache (customId) {
-        return manualCacheMethods(client, this, customId)
-      }
+      manualCache (customId) { return manualCacheMethods(client, this, customId) }
     },
     instanceMethods: {
-      cache () {
-        return instanceMethods(client, this)
-      }
+      cache () { return instanceMethods(client, this) }
     }
   }
 }

--- a/packages/sequelize-transparent-cache/lib/methods/class.js
+++ b/packages/sequelize-transparent-cache/lib/methods/class.js
@@ -37,4 +37,28 @@ function classMethods (client, model) {
   }
 }
 
-module.exports = classMethods
+function manualCacheMethods (client, model, customKey) {
+  return {
+    client () {
+      return client
+    },
+    findAll () {
+      return cache.get(client, model, customKey)
+        .then(instance => {
+          if (instance) {
+            return instance
+          }
+          return model.find.apply(model, arguments)
+            .then(instance => cache.save(client, instance, customKey))
+        })
+    },
+    find () {
+      return this.findAll.apply(this, arguments)
+    },
+    clear () {
+      return cache.clearKey(client, model, customKey)
+    }
+  }
+}
+
+module.exports = { classMethods, manualCacheMethods }

--- a/packages/sequelize-transparent-cache/test/classMethods.js
+++ b/packages/sequelize-transparent-cache/test/classMethods.js
@@ -135,12 +135,10 @@ t.test('Class methods', async t => {
       'User cached afrer find and present in key'
     )
 
-    await User.manualCache(key).clear();
+    await User.manualCache(key).clear()
     t.notOk(
       cacheStore.User[key],
       'User was deleted from cache'
     )
   })
-
-
 })

--- a/packages/sequelize-transparent-cache/test/classMethods.js
+++ b/packages/sequelize-transparent-cache/test/classMethods.js
@@ -6,7 +6,7 @@ const Article = sequelize.models.Article
 const Comment = sequelize.models.Comment
 const cacheStore = User.cache().client().store
 
-t.test('Instance methods', async t => {
+t.test('Class methods', async t => {
   await sequelize.sync()
 
   t.deepEqual(cacheStore, {}, 'Cache is empty on start')
@@ -93,4 +93,54 @@ t.test('Instance methods', async t => {
       'Retrieved user with Article association'
     )
   })
+
+  t.test('manualCache -> find', async t => {
+    t.is(await User.manualCache('sasas').find({ where: { name: 'Not existent' } }), null, 'Cache miss not causing any problem')
+
+    const key = 'IvanUserCacheKey'
+    const manualTest = await User.manualCache(key).find({ where: { name: 'Ivan' }, include: [{ model: Article, as: 'Articles' }] })
+    t.is(
+      manualTest.get().Articles[0].get().uuid,
+      (await User.cache().findById(1, { include: [{ model: Article, as: 'Articles' }] })).get().Articles[0].get().uuid,
+      'Retrieved User with Article association using find method'
+    )
+
+    delete cacheStore.User[key]
+    const secondManualTest = await User.manualCache(key).find({ where: { name: 'Ivan' }, include: [{ model: Article, as: 'Articles' }] })
+    const thirdManualTest = await User.manualCache(key).find({ where: { name: 'Ivan' }, include: [{ model: Article, as: 'Articles' }] })
+    t.is(
+      secondManualTest.get().Articles[0].get().uuid,
+      thirdManualTest.get().Articles[0].get().uuid,
+      'Retrieved User with Article association from DB and cache'
+    )
+  })
+
+  t.test('manualCache -> cache store', async t => {
+    const key = 'ClearStoreUserCacheKey'
+    const manualCacheStore = User.manualCache().client().store
+    const manualTest = await User.manualCache(key).find({ where: { name: 'Ivan' } })
+    t.deepEqual(
+      manualCacheStore.User[key],
+      manualTest.get(),
+      'User cached afrer find and present in key using manualCache store'
+    )
+  })
+
+  t.test('manualCache -> clear', async t => {
+    const key = 'ClearUserCacheKey'
+    const manualTest = await User.manualCache(key).find({ where: { name: 'Ivan' } })
+    t.deepEqual(
+      cacheStore.User[key],
+      manualTest.get(),
+      'User cached afrer find and present in key'
+    )
+
+    await User.manualCache(key).clear();
+    t.notOk(
+      cacheStore.User[key],
+      'User was deleted from cache'
+    )
+  })
+
+
 })

--- a/packages/sequelize-transparent-cache/test/helpers/sequelize.js
+++ b/packages/sequelize-transparent-cache/test/helpers/sequelize.js
@@ -14,9 +14,10 @@ const options = {
 }
 
 if (Sequelize.version.startsWith('3')) { // Using global define
-  const { instanceMethods, classMethods } = sequelizeCache(variableAdaptor)
+  const { instanceMethods, classMethods, manualCacheMethods } = sequelizeCache(variableAdaptor)
   options.define.instanceMethods = instanceMethods
   options.define.classMethods = classMethods
+  options.define.manualCacheMethods = manualCacheMethods
 }
 
 const sequelize = new Sequelize(options)


### PR DESCRIPTION
As discussed on this issue:

https://github.com/DanielHreben/sequelize-transparent-cache/issues/29

I added the possibility to cache complex queries using a manualCache() set of functions.

These cache methods rely on the user/developer providing a custom key for each of its queries. This key is then combined with the model name to provide more uniqueness to the set of keys.

Let me know if you have any questions or concerns