### PR TITLE
Added global error handler to Memcached adapter to handle connection errors gracefully

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -11,6 +11,6 @@ ratings:
   paths:
   - packages/**
 
-exclude_paths:
-- examples/
-- __test__/
+exclude_patterns:
+- "examples/"
+- "__test__/"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -13,4 +13,4 @@ ratings:
 
 exclude_patterns:
 - "examples/"
-- "__test__/"
+- "**/__test__/"

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 coverage
 *.log
 package-lock.json
+.idea

--- a/packages/sequelize-transparent-cache-memcached/README.md
+++ b/packages/sequelize-transparent-cache-memcached/README.md
@@ -14,17 +14,19 @@ const MemcachedAdaptor = require('sequelize-transparent-cache-memcached')
 const memcachedAdaptor = new MemcachedAdaptor({
   client: memcached,
   namespace: 'model', // optional
-  lifetime: 60 * 60
+  lifetime: 60 * 60,
+  errorHandler: (error, operation, key) => {...} // optional
 })
 ```
 
 ## Constructor arguments
 
-| Param       | Type             | Required | Description                                                                     |
-|-------------|------------------|----------|---------------------------------------------------------------------------------|
-| `client`    | memcached instance | yes      | Configured [memcached instance](https://www.npmjs.com/package/memcached#setting-up-the-client) |
-| `namespace` | string           | no       | Prefix for all keys                                                             |
-| `lifetime`  | integer          | yes       | Keys lifetime, seconds                                                          |
+| Param          | Type               | Required | Description                                                                     |
+|----------------|--------------------|----------|---------------------------------------------------------------------------------|
+| `client`       | memcached instance | yes      | Configured [memcached instance](https://www.npmjs.com/package/memcached#setting-up-the-client) |
+| `namespace`    | string             | no       | Prefix for all keys                                                             |
+| `lifetime`     | integer            | yes      | Keys lifetime, seconds                                                          |
+| `errorHandler` | function           | no       |  Global error handler function that is invoked on error instead of rejecting a returned Promise. It takes `error` thrown, `operation` (`set`/`get`/`del`), cache `key` |
 
 ## Storing format
 Each object stored as single JSON string.

--- a/packages/sequelize-transparent-cache-memcached/README.md
+++ b/packages/sequelize-transparent-cache-memcached/README.md
@@ -15,7 +15,9 @@ const memcachedAdaptor = new MemcachedAdaptor({
   client: memcached,
   namespace: 'model', // optional
   lifetime: 60 * 60,
-  errorHandler: (error, operation, key) => {...} // optional
+  errorHandler: (error, operation, cacheKey) => { // optional
+    console.warn(`Memcached error on attempt to ${operation} ${cacheKey}`, error)
+  } 
 })
 ```
 
@@ -26,7 +28,16 @@ const memcachedAdaptor = new MemcachedAdaptor({
 | `client`       | memcached instance | yes      | Configured [memcached instance](https://www.npmjs.com/package/memcached#setting-up-the-client) |
 | `namespace`    | string             | no       | Prefix for all keys                                                             |
 | `lifetime`     | integer            | yes      | Keys lifetime, seconds                                                          |
-| `errorHandler` | function           | no       |  Global error handler function that is invoked on error instead of rejecting a returned Promise. It takes `error` thrown, `operation` (`set`/`get`/`del`), cache `key` |
+| `errorHandler` | function           | no       |  Global error handler function. It takes `error` thrown, string `operation` (`set`/`get`/`del`), string `cacheKey` |
+
+#### Using global error handler
+If `errorHandler` function is specified in constructor parameters, it becomes responsible for handling errors thrown 
+by Memcached. It's handy if you want Memcached errors to be swallowed inside the adapter instead of interrupting 
+external caller code.
+* Handler is invoked on errors instead of rejecting a resulting Promise. 
+* The value returned by error handler is used as an operation result to resolve resulting Promise. 
+* If error handler throws an error, it's propagated to the caller code with no additional interception. It may be used 
+to forcely rethrow the original error.
 
 ## Storing format
 Each object stored as single JSON string.

--- a/packages/sequelize-transparent-cache-memcached/src/__test__/memcache-adaptor.test.js
+++ b/packages/sequelize-transparent-cache-memcached/src/__test__/memcache-adaptor.test.js
@@ -1,0 +1,85 @@
+const Memcached = require('memcached')
+const MemcacheAdaptor = require('..')
+
+describe('No error handler', () => {
+  const memcached = new Memcached()
+  const memcachedAdaptor = new MemcacheAdaptor({
+    client: memcached,
+    namespace: 'model',
+    lifetime: 60 * 60
+  })
+
+  describe('Adaptor methods', () => {
+    const data = { test: 1 }
+    const key = ['complex', 'key']
+
+    test('set', async () => {
+      expect(await memcachedAdaptor.set(key, data)).toEqual(undefined)
+    })
+
+    test('get', async () => {
+      expect(await memcachedAdaptor.get(['missing'])).toBeUndefined()
+      expect(await memcachedAdaptor.get(key)).toEqual(data)
+    })
+
+    test('del', async () => {
+      await memcachedAdaptor.del(key)
+
+      expect(await memcachedAdaptor.get(key)).toBeUndefined()
+    })
+  })
+})
+
+describe('With error handler', () => {
+  describe('Adaptor methods', () => {
+    const data = { test: 1 }
+    const key = ['complex', 'key']
+    const mockedMemcached = {
+      set (key, value, lifetime, callback) {
+        setImmediate(() => callback(new Error('mock set error')))
+      },
+      get (key, callback) {
+        setImmediate(() => callback(new Error('mock get error')))
+      },
+      del (key, callback) {
+        setImmediate(() => callback(new Error('mock del error')))
+      }
+    }
+    const noData = 'no-data-stub'
+    let memcachedAdaptor
+
+    beforeEach(() => {
+      memcachedAdaptor = new MemcacheAdaptor({
+        client: mockedMemcached,
+        namespace: 'model',
+        lifetime: 60 * 60,
+        errorHandler: jest.fn().mockReturnValue(noData)
+      })
+    })
+
+    test('set', async () => {
+      expect(await memcachedAdaptor.set(key, data)).toEqual(noData)
+      expect(memcachedAdaptor.errorHandler.mock.calls.length).toEqual(1)
+      expect(memcachedAdaptor.errorHandler.mock.calls[0][0]).toBeDefined()
+      expect(memcachedAdaptor.errorHandler.mock.calls[0][1]).toBe('set')
+      expect(memcachedAdaptor.errorHandler.mock.calls[0][2]).toBe('model:complex:key')
+    })
+
+    test('get', async () => {
+      expect(await memcachedAdaptor.get(key)).toEqual(noData)
+      expect(memcachedAdaptor.errorHandler.mock.calls.length).toEqual(1)
+      expect(memcachedAdaptor.errorHandler.mock.calls[0][0]).toBeDefined()
+      expect(memcachedAdaptor.errorHandler.mock.calls[0][1]).toBe('get')
+      expect(memcachedAdaptor.errorHandler.mock.calls[0][2]).toBe('model:complex:key')
+    })
+
+    test('del', async () => {
+      expect(await memcachedAdaptor.del(key)).toEqual(noData)
+
+      expect(memcachedAdaptor.errorHandler.mock.calls.length).toEqual(1)
+      expect(memcachedAdaptor.errorHandler.mock.calls[0][0]).toBeDefined()
+      expect(memcachedAdaptor.errorHandler.mock.calls[0][1]).toBe('del')
+      expect(memcachedAdaptor.errorHandler.mock.calls[0][2]).toBe('model:complex:key')
+    })
+  })
+})

--- a/packages/sequelize-transparent-cache-memcached/src/memcached-adaptor.js
+++ b/packages/sequelize-transparent-cache-memcached/src/memcached-adaptor.js
@@ -82,7 +82,11 @@ class MemcachedAdaptor {
 
   _onError (error, resolve, reject, operation, key) {
     if (this.errorHandler) {
-      resolve(this.errorHandler(error, operation, key))
+      try {
+        resolve(this.errorHandler(error, operation, key))
+      } catch (nestedError) {
+        reject(nestedError)
+      }
     } else {
       reject(error)
     }


### PR DESCRIPTION
Hello!
My app is running on AWS and connects to Amazon ElastiCache. Sometimes AWS has connectivity issues or node crushed or it just decides to restart Memcached cluster. If during this period my app calls any method from the cache wrapper like the following, Memcached client throws an error and the whole request processing interrupts.
```javascript
// Load user from cache
const user = await User.cache().findByPk(1); // Error: Memcached connection error!

// Update in db and cache
await user.cache().update({ // Error: Memcached connection error!
  name: 'Vikki'
})
```
It would be great if there was a possibility to swallow a connection error in that case and fall back to DB queries.
My PR contains this enhancement. Please review.
The change is backward-compatible and activated on demand only by passing a handler to wrapper constructor. Current and new behavior are covered with tests, all tests are passing locally.