### PR TITLE
feat!: drop sequelize v5 support

### DIFF
--- a/.github/workflows/node_tests.yaml
+++ b/.github/workflows/node_tests.yaml
@@ -39,7 +39,7 @@ jobs:
       matrix:
         # Test against the latest LTS versions
         node-version: [20.x, 22.x]
-        sequelize-version: ["^5.21.6", "^6.0.0"]
+        sequelize-version: ["^6.0.0"]
 
     steps:
     - name: Checkout repository

--- a/packages/sequelize-transparent-cache/package.json
+++ b/packages/sequelize-transparent-cache/package.json
@@ -3,11 +3,7 @@
   "name": "sequelize-transparent-cache",
   "description": "Simple to use and universal cache layer for Sequelize",
   "main": "src/index.js",
-  "keywords": [
-    "sequelize",
-    "cache",
-    "plugin"
-  ],
+  "keywords": ["sequelize", "cache", "plugin"],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/sequelize-transparent-cache/sequelize-transparent-cache.git"
@@ -18,7 +14,7 @@
   },
   "license": "CC-BY-4.0",
   "peerDependencies": {
-    "sequelize": ">=5"
+    "sequelize": ">=6"
   },
   "devDependencies": {
     "sequelize": "^6.37.8",


### PR DESCRIPTION
BREAKING CHANGE: Drop support for sequelize < 6.0.0 

Has been deprecated since Dec 2021