### PR TITLE
fix!: lerna publishing

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,13 +1,17 @@
 {
-  "packages": [
-    "packages/*"
-  ],
+  "packages": ["packages/*"],
   "command": {
     "publish": {
-      "registry": "https://registry.npmjs.org/"
+      "registry": "https://registry.npmjs.org/",
+      "ignoreChanges": ["**/__tests__/**"]
+    },
+    "version": {
+      "conventionalCommits": true
     }
   },
-  "conventionalCommits": true,
-  "version": "2.6.1",
+  "version": "2.6.0",
+  "changelogPreset": {
+    "name": "conventionalcommits"
+  },
   "npmClient": "npm"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
         "packages/*"
       ],
       "devDependencies": {
+        "conventional-changelog-conventionalcommits": "^9.3.1",
         "eslint": "^9.39.4",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-import": "^2.32.0",
@@ -5382,6 +5383,19 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/conventional-changelog-conventionalcommits": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.3.1.tgz",
+      "integrity": "sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/conventional-changelog-core": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "lint": "eslint ."
   },
   "devDependencies": {
+    "conventional-changelog-conventionalcommits": "^9.3.1",
     "eslint": "^9.39.4",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-import": "^2.32.0",

--- a/packages/sequelize-transparent-cache-ioredis/.npmignore
+++ b/packages/sequelize-transparent-cache-ioredis/.npmignore
@@ -1,0 +1,5 @@
+node_modules
+.nyc_output
+coverage
+*.log
+__test__

--- a/packages/sequelize-transparent-cache-memcache-plus/.npmignore
+++ b/packages/sequelize-transparent-cache-memcache-plus/.npmignore
@@ -1,0 +1,5 @@
+node_modules
+.nyc_output
+coverage
+*.log
+__test__

--- a/packages/sequelize-transparent-cache-memcached/.npmignore
+++ b/packages/sequelize-transparent-cache-memcached/.npmignore
@@ -1,0 +1,5 @@
+node_modules
+.nyc_output
+coverage
+*.log
+__test__

--- a/packages/sequelize-transparent-cache-nats/.npmignore
+++ b/packages/sequelize-transparent-cache-nats/.npmignore
@@ -1,0 +1,5 @@
+node_modules
+.nyc_output
+coverage
+*.log
+__test__

--- a/packages/sequelize-transparent-cache-variable/.npmignore
+++ b/packages/sequelize-transparent-cache-variable/.npmignore
@@ -1,0 +1,5 @@
+node_modules
+.nyc_output
+coverage
+*.log
+__test__

--- a/packages/sequelize-transparent-cache/.npmignore
+++ b/packages/sequelize-transparent-cache/.npmignore
@@ -1,0 +1,5 @@
+node_modules
+.nyc_output
+coverage
+*.log
+__test__


### PR DESCRIPTION
The recent changes to address versioning issues were incomplete and didn't pick up the breaking change commit.

```
➜  sequelize-transparent-cache git:() npx lerna publish --no-push --conventional-commits
lerna notice cli v9.0.7
lerna info publish rooted leaf detected, skipping synthetic root lifecycles
lerna info current version 2.6.0
lerna info Looking for changed packages since v2.6.1
lerna info ignoring diff in paths matching [ '**/__tests__/**' ]
lerna info getChangelogConfig Auto-prefixing conventional-changelog preset "conventionalcommits"
lerna info getChangelogConfig Successfully resolved preset "conventional-changelog-conventionalcommits"

Changes:
 - sequelize-transparent-cache: 2.6.1 => 3.0.0
 - sequelize-transparent-cache-ioredis: 2.6.1 => 3.0.0
 - sequelize-transparent-cache-memcache-plus: 2.6.1 => 3.0.0
 - sequelize-transparent-cache-memcached: 2.6.1 => 3.0.0
 - sequelize-transparent-cache-nats: 2.6.0 => 3.0.0
 - sequelize-transparent-cache-variable: 2.6.1 => 3.0.0
```
